### PR TITLE
fix: revert monitor maxItems limit from 100 back to 500

### DIFF
--- a/src/jsonSchema/saveDataBodySchema.ts
+++ b/src/jsonSchema/saveDataBodySchema.ts
@@ -130,7 +130,7 @@ export const saveDataBodySchemaV4 = {
         },
         monitor: {
             type: "array",
-            maxItems: 100,
+            maxItems: 500,
             items: {
                 type: "object",
                 required: ["timestamp", "name", "cpu", "mem"],


### PR DESCRIPTION
The maxItems limit was reduced from 500 to 100 in commit 915576999a1 (June 14, 2024) which breaks compatibility with the Locust.io "Continuous Loading of Results"  integration script.

This change specifically reverts only the maxItems value while preserving all other changes from that commit.

Fixes #326